### PR TITLE
feat: add trading_pair_info.go

### DIFF
--- a/pkg/bitopro/trading_pair_info.go
+++ b/pkg/bitopro/trading_pair_info.go
@@ -1,0 +1,56 @@
+package bitopro
+
+import (
+	"encoding/json"
+
+	"github.com/bitoex/bitopro-api-go/internal"
+)
+
+type TradingPairInfo struct {
+    Pair                        string  `json:"pair"`
+    Base                        string  `json:"base"`
+    Quote                       string  `json:"quote"`
+    BasePrecision               string  `json:"basePrecision"`
+    QuotePrecision              string  `json:"quotePrecision"`
+    MinLimitBaseAmount          string  `json:"minLimitBaseAmount"`
+    MaxLimitBaseAmount          string  `json:"maxLimitBaseAmount"`
+    MinMarketBuyQuoteAmount     string  `json:"minMarketBuyQuoteAmount"`
+    OrderOpenLimit              string  `json:"orderOpenLimit"`
+    Maintain                    bool    `json:"maintain"`
+    OrderBookQuotePrecision     string  `json:"orderBookQuotePrecision"`
+    OrderBookQuoteScaleLevel    string  `json:"orderBookQuoteScaleLevel"`
+    AmountPrecision             string  `json:"amountPrecision"`
+}
+
+type TradingPairInfos struct {
+    Data []TradingPairInfo `json:"data,omitempty"`
+    StatusCode
+}
+
+func getTradingPairInfos(proxy string) *TradingPairInfos {
+	var data TradingPairInfos
+
+	code, res, err := internal.ReqPublic("v3/provisioning/trading-pairs", proxy)
+	if err != nil {
+		data.Error = err.Error()
+	} else {
+		if err := json.Unmarshal([]byte(res), &data); err != nil {
+			data.Error = res
+		}
+	}
+
+	data.Code = code
+
+	return &data
+}
+
+
+// GetTradingPairInfos Ref. https://github.com/bitoex/bitopro-offical-api-docs/blob/master/api/v3/public/get_trading_pair_info.md
+func (p *PubAPI) GetTradingPairInfos() *TradingPairInfos {
+	return getTradingPairInfos(p.proxy)
+}
+
+// GetTradingPairInfos Ref. https://github.com/bitoex/bitopro-offical-api-docs/blob/master/api/v3/public/get_trading_pair_info.md
+func (a *AuthAPI) GetTradingPairInfos() *TradingPairInfos {
+	return getTradingPairInfos(a.proxy)
+}

--- a/pkg/bitopro/trading_pair_info_test.go
+++ b/pkg/bitopro/trading_pair_info_test.go
@@ -1,0 +1,20 @@
+package bitopro
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAuthAPI_GetTradingPairInfos(t *testing.T) {
+	if json, err := json.MarshalIndent(GetPubClient().GetTradingPairInfos(), "", "  "); err != nil {
+		t.Error(err)
+	} else {
+		t.Logf("\n%s", string(json))
+	}
+
+	if json, err := json.MarshalIndent(getAuthClient().GetTradingPairInfos(), "", "  "); err != nil {
+		t.Error(err)
+	} else {
+		t.Logf("\n%s", string(json))
+	}
+}


### PR DESCRIPTION
added get_trading_pair_info functionality
[get_trading_pair_info](https://github.com/bitoex/bitopro-offical-api-docs/blob/master/api/v3/public/get_trading_pair_info.md)
